### PR TITLE
fix: change core-js version to 3

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,7 +6,7 @@
       "@babel/preset-env",
       {
         "corejs": {
-          "version": "2",
+          "version": "3",
           "proposals": true
         },
         "useBuiltIns": "usage"

--- a/.babelrc
+++ b/.babelrc
@@ -4,13 +4,7 @@
     "@babel/preset-flow",
     [
       "@babel/preset-env",
-      {
-        "corejs": {
-          "version": "3",
-          "proposals": true
-        },
-        "useBuiltIns": "usage"
-      }
+      {}
     ]
   ],
   "plugins": [

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@babel/cli": "^7.12.10",
     "@babel/core": "^7.11.1",
     "@babel/plugin-transform-destructuring": "^7.10.4",
-    "@babel/polyfill": "^7.10.4",
     "@babel/preset-env": "^7.11.0",
     "@babel/preset-flow": "^7.10.4",
     "@babel/preset-react": "^7.10.4",


### PR DESCRIPTION
update corejs verion to 3. 
using v2 generates the following error on Node v12
```
17:10:50.326  	Failed to compile.
17:10:50.327  	ModuleNotFoundError: Module not found: Error: Can't resolve 'core-js/modules/es6.object.define-property.js' in '/vercel/workpath0/node_modules/outline-icons/lib'
17:10:50.327  	> Build error occurred
17:10:50.328  	Error: > Build failed because of webpack errors
17:10:50.328  	    at build (/vercel/workpath0/node_modules/next/dist/build/index.js:15:918)
17:10:50.328  	    at runMicrotasks (<anonymous>)
17:10:50.328  	    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```