### PR TITLE
Allow React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "typescript": "^4.5.2"
   },
   "peerDependencies": {
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react": "^17.0.0 || ^18.0.0"
   }
 }


### PR DESCRIPTION
- Adds React 18 to the peerDependencies
- Remove react-dom from the peerDependencies, allowing server rendered frameworks like NextJS to use the package without the unnecessary react-dom dependency 